### PR TITLE
task(AK-51489): add PR merge gates and gitleaks pre-commit hook

### DIFF
--- a/.github/workflows/dependabot-gate.yml
+++ b/.github/workflows/dependabot-gate.yml
@@ -1,0 +1,25 @@
+name: Dependabot Alert Gate
+on: [pull_request]
+
+permissions:
+  security-events: read
+  contents: read
+
+jobs:
+  check-alerts:
+    name: Check Dependabot Alerts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for open HIGH+ alerts
+        env:
+          GH_TOKEN: ${{ secrets.AK_BUILDBOT_PAT }}
+        run: |
+          alerts=$(gh api repos/${{ github.repository }}/dependabot/alerts \
+            --jq '[.[] | select(.state=="open" and (.security_advisory.severity=="high" or .security_advisory.severity=="critical"))]')
+          count=$(echo "$alerts" | jq 'length')
+          if [ "$count" -gt 0 ]; then
+            echo "::error::$count open HIGH/CRITICAL Dependabot alerts must be resolved before merging"
+            echo "$alerts" | jq -r '.[] | "  - \(.security_advisory.severity | ascii_upcase): \(.security_vulnerability.package.name) — \(.security_advisory.summary)"'
+            exit 1
+          fi
+          echo "No open HIGH/CRITICAL Dependabot alerts"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1
+    hooks:
+      - id: gitleaks


### PR DESCRIPTION
Replicates the security gates added in route-collector-server#680 to all routing-team repos.

**Changes:**
- `.github/workflows/dependabot-gate.yml` — advisory PR gate; fails if open HIGH/CRITICAL Dependabot alerts exist
- `.pre-commit-config.yaml` — gitleaks v8.30.1 secret scanning pre-commit hook

**Note:** The gate workflow is advisory only. The `AK_BUILDBOT_PAT` org secret is already available.

Part of AK-51489.